### PR TITLE
Smart sizing for dialogs

### DIFF
--- a/widgetui/dialogs/edititemdialog.cpp
+++ b/widgetui/dialogs/edititemdialog.cpp
@@ -10,6 +10,10 @@ EditItemDialog::EditItemDialog(QWidget *parent) :
     currentItem = 0;
     connect(this, SIGNAL(finished(int)), this, SLOT(applySettings()));
     connect(ui->deleteButton, SIGNAL(clicked()), this, SLOT(deleteItemClicked()));
+
+    setGeometry(parent->x() + parent->width()/2 - parent->width()*0.35,
+        parent->y() + parent->height()/2 - parent->height()*0.35,
+        parent->width()*0.7, parent->height()*0.7);
 }
 
 EditItemDialog::~EditItemDialog()

--- a/widgetui/dialogs/panelitemselectiondialog.cpp
+++ b/widgetui/dialogs/panelitemselectiondialog.cpp
@@ -24,6 +24,15 @@ PanelItemSelectionDialog::PanelItemSelectionDialog(QWidget *parent) :
     QList<int> sizes;
     sizes << 50 << 50;
     ui->splitter->setSizes(sizes);
+
+    setGeometry(parent->x() + parent->width()/2 - parent->width()*0.35,
+        parent->y() + parent->height()/2 - parent->height()*0.35,
+        parent->width()*0.7, parent->height()*0.7);
+
+    ui->itemList->setAttribute(Qt::WA_AcceptTouchEvents,true);
+    ui->itemList->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    ui->itemList->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+    QScroller::grabGesture(ui->itemList,QScroller::LeftMouseButtonGesture);
 }
 
 PanelItemSelectionDialog::~PanelItemSelectionDialog() {

--- a/widgetui/dialogs/panelitemselectiondialog.h
+++ b/widgetui/dialogs/panelitemselectiondialog.h
@@ -5,6 +5,7 @@
 #include <QDialog>
 #include <QListWidgetItem>
 #include <QGraphicsScene>
+#include <QScroller>
 #include "../panelitemfactory.h"
 #include "simulatedextplaneconnection.h"
 #include "extplaneconnection.h"

--- a/widgetui/dialogs/settingsdialog.cpp
+++ b/widgetui/dialogs/settingsdialog.cpp
@@ -17,6 +17,10 @@ SettingsDialog::SettingsDialog(QWidget *parent, Settings *appSettings) :
     connect(ui->autoPanelsCheckbox, SIGNAL(toggled(bool)), this, SIGNAL(setAutoPanelsEnabled(bool)));
     connect(ui->adjustPowerCheckbox, SIGNAL(toggled(bool)), this, SIGNAL(setAdjustPowerEnabled(bool)));
     connect(this, SIGNAL(finished(int)), this, SLOT(saveSettings()));
+
+    setGeometry(parent->x() + parent->width()/2 - parent->width()*0.35,
+        parent->y() + parent->height()/2 - parent->height()*0.35,
+        parent->width()*0.7, parent->height()*0.7);
 }
 
 SettingsDialog::~SettingsDialog() {

--- a/widgetui/menubutton.cpp
+++ b/widgetui/menubutton.cpp
@@ -18,7 +18,7 @@ MenuButton::MenuButton(QWidget *parent) : QObject(parent), side(20) {
     // Init
     panelWindow = parent;
     #ifdef MOBILE_DEVICE
-        side = 50;
+        side = 80;
     #endif
     editMode = false;
     currentMenu = NULL;
@@ -29,7 +29,7 @@ void MenuButton::paint(QPainter *painter, const QStyleOptionGraphicsItem *option
     Q_UNUSED(widget);
     painter->setRenderHint(QPainter::Antialiasing);
     painter->setBrush(Qt::NoBrush);
-    painter->setPen(Qt::yellow);
+    painter->setPen(QPen(Qt::yellow,20));
     //painter->drawRect(0,0,side,side);
     painter->drawLine(0,side,side,0);
 }

--- a/widgetui/panelitems/altimeter.cpp
+++ b/widgetui/panelitems/altimeter.cpp
@@ -221,14 +221,14 @@ void Altimeter::createSettings(QGridLayout *layout) {
     DistanceUnitComboBox *unitsCombo = new DistanceUnitComboBox(layout->parentWidget(), units);
     connect(unitsCombo, SIGNAL(unitSelected(DistanceUnit)), this, SLOT(setUnit(DistanceUnit)));
     layout->addWidget(unitsCombo);
-    QLabel *range1Label = new QLabel("Range", layout->parentWidget());
+    QLabel *range1Label = new QLabel("Range big hand", layout->parentWidget());
     layout->addWidget(range1Label);
     NumberInputLineEdit *range1Edit = new NumberInputLineEdit(layout->parentWidget());
     range1Edit->setText(QString::number(_range1));
     layout->addWidget(range1Edit);
     connect(range1Edit, SIGNAL(valueChangedFloat(float)), this, SLOT(setRange1(float)));
 
-    QLabel *range2Label = new QLabel("Range 2", layout->parentWidget());
+    QLabel *range2Label = new QLabel("Range small hand", layout->parentWidget());
     layout->addWidget(range2Label);
     NumberInputLineEdit *range2Edit = new NumberInputLineEdit(layout->parentWidget());
     range2Edit->setText(QString::number(_range2));


### PR DESCRIPTION

- Settings, Edit Item, and Add Item dialogs are no longer fixed size but proportional to the parent window. It is especially useful on mobile devices.
- Touch scroll is enabled on Add Item dialog
- Menu button is enlarged and thickened. Much easier to operate on touch devices.
- Clarified label of Range settings for Altimeter.